### PR TITLE
Fix: Return HTTP 500 for database failures (was 503)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -459,9 +459,10 @@ async def get_items(session: AsyncSession = Depends(get_session)):
         return await read_items(session)
     except SQLAlchemyError as exc:
         logger.error("database_error", extra={"error": str(exc)})
+        # Return 500 Internal Server Error for database failures
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Database service unavailable: {str(exc)}",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(exc)}",
         ) from exc
     except Exception as exc:
         logger.exception("unexpected_error", extra={"error": str(exc)})
@@ -473,7 +474,7 @@ async def get_items(session: AsyncSession = Depends(get_session)):
 
 **Changes:**
 1. Split exception handling: `SQLAlchemyError` vs generic `Exception`
-2. Return HTTP 503 for database failures (service unavailable)
+2. Return HTTP 500 for database failures (was 404)
 3. Return HTTP 500 for unexpected errors
 4. Log actual error details instead of generic "items_list_failed_as_not_found"
 5. Include error message in HTTP response for debugging
@@ -532,5 +533,5 @@ The system looks healthy.
 - **Scheduled health check created:** ✅ Cron-based job runs every 2 minutes
 - **Proactive reports working:** ✅ Agent posts health updates to chat
 - **Planted bug identified:** ✅ Broad `except Exception` hiding database errors as 404
-- **Bug fixed:** ✅ Now returns 503 for DB failures, 500 for unexpected errors
+- **Bug fixed:** ✅ Now returns HTTP 500 for database failures (was 404)
 - **Recovery verified:** ✅ Agent reports healthy system after PostgreSQL restart

--- a/backend/src/lms_backend/routers/items.py
+++ b/backend/src/lms_backend/routers/items.py
@@ -29,10 +29,10 @@ async def get_items(session: AsyncSession = Depends(get_session)):
                 "error_type": type(exc).__name__,
             },
         )
-        # Return 503 Service Unavailable for database failures
+        # Return 500 Internal Server Error for database failures
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Database service unavailable: {str(exc)}",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(exc)}",
         ) from exc
     except Exception as exc:
         # Log unexpected errors


### PR DESCRIPTION
The test expects HTTP 500 for database failures, not 503. Updated backend/src/lms_backend/routers/items.py to return HTTP 500 INTERNAL SERVER ERROR for both SQLAlchemyError and generic Exception cases.

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #7

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
